### PR TITLE
fix flutter format .

### DIFF
--- a/openapi-generator/lib/src/openapi_generator_runner.dart
+++ b/openapi-generator/lib/src/openapi_generator_runner.dart
@@ -182,6 +182,7 @@ class OpenapiGenerator extends GeneratorForAnnotation<annots.Openapi> {
             'format',
             '.',
           ],
+          runInShell: true , 
         );
       }
     } catch (e) {


### PR DESCRIPTION
# Context
when running 
`
flutter pub run build_runner build --delete-conflicting-outputs
`
Getting error after generating file
![image](https://user-images.githubusercontent.com/39813642/218313204-19844f62-2143-4c6b-85a4-571df3801b82.png)

platform: windows 10
Flutter version : 3.7.3 ( stable )


